### PR TITLE
Fix corpse photo order asc

### DIFF
--- a/server/api/corpses.js
+++ b/server/api/corpses.js
@@ -48,7 +48,8 @@ router.param('corpseId', (req, res, next, id) => {
         {model: Assignment},
         {model: User, attributes: ['id', 'username', 'email']},
         {model: Like, attributes: ['id', 'userId']}
-      ]
+      ],
+      order: [ [ Photo, 'id', 'ASC'] ]
     })
     .then(corpse => {
       if (!corpse) {


### PR DESCRIPTION
This fix adjusts eager loading to sort by photo.id ascending so photo[0] is always the top, photo[1] is always the 'next' photo, etc....